### PR TITLE
Fix NativeScript version >4 check

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,7 +17,7 @@ module.exports = {
     getPathToPlatformAssets(hookArgs, $projectData) {
         let pathToPlatformAssets;
         let currentNVersion = this.getNativeScriptVersion($projectData);
-        if (currentNVersion[0] >= 3 && currentNVersion[1] >= 4) {
+        if (currentNVersion[0] >= 4 || (currentNVersion[0] === 3 && currentNVersion[1] >= 4)) {
             pathToPlatformAssets = path.join($projectData.platformsDir, "/android/app/src/main/assets");
         } else {
             pathToPlatformAssets = path.join($projectData.platformsDir, "/android/src/main/assets");


### PR DESCRIPTION
This pull request fixes the issue where getPathToPlatformAssets function in lib/utils.js was not properly checking NativeScript versions above 3. 
Wrong platform assets path was being used for versions above 4.0. 
