### PR TITLE
Fix path to platform assets issue

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,16 +12,14 @@ module.exports = {
     },
     getNativeScriptVersion($projectData) {
         // [3, 4, 1]
-        return $projectData.$projectHelper.$staticConfig.version.split(".");
+        const version = $projectData.$projectHelper.$staticConfig.version;
+        return parseInt(version.replace(/(\.)/g, ""));
     },
     getPathToPlatformAssets(hookArgs, $projectData) {
-        let pathToPlatformAssets;
-        let currentNVersion = this.getNativeScriptVersion($projectData);
-        if (currentNVersion[0] >= 3 && currentNVersion[1] >= 4) {
-            pathToPlatformAssets = path.join($projectData.platformsDir, "/android/app/src/main/assets");
-        } else {
-            pathToPlatformAssets = path.join($projectData.platformsDir, "/android/src/main/assets");
-        }
+        const version = this.getNativeScriptVersion($projectData);
+        const assetsDir = `android/${ version >= 341 ? "app/src" : "src" }/main/assets`;
+        const pathToPlatformAssets = path.join($projectData.platformsDir, assetsDir);
+        
         return pathToPlatformAssets;
     },
     getPathToAppPlatformAssets(hookArgs, $projectData) {


### PR DESCRIPTION
### There's a problem with the fix made for #2. 
At the moment this code fails if `currentNVersion[1] < 4`. So `{N} version 3.4.1` passes as expected, but `{N} version 4.1.1` fails.

---

The changes I've made affect two methods in `utils.js`.

##### getNativeScriptVersion(...)
  * Instead of returning an array, now returns an Int. This simplifies the version check in getPathToPlatformAssets.

##### getPathToPlatformAssets(...)
  * Removed if/else statement and repetitive code. Replaces with template literal and ternary operator.